### PR TITLE
자모가 초성, 중성, 종성 코드로 분리되도록 수정

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 from multiprocessing import Pool
 from tqdm import tqdm
 from glob import glob
-from jamo import h2j, j2hcj
+from jamo import hangul_to_jamo
 
 import matplotlib
 matplotlib.use('pdf')
@@ -67,7 +67,7 @@ def get_korean_dictionary(transcripts, g2p):
 		word_p_list = g2p(transcript.rstrip()).split(" ")
 
 		for word, word_p in list(zip(word_list, word_p_list)):
-			word_p = " ".join(list(j2hcj(h2j(word_p))))
+			word_p = " ".join(list(hangul_to_jamo(word_p)))
 			line = "{}\t{}\n".format(word, word_p)
 			if word not in pronunciation_dict:
 				pronunciation_dict.append(line)


### PR DESCRIPTION
안녕하세요. 이재홍입니다.

MFARunner를 사용하던 중 버그를 발견하게 되어 풀리퀘스트를 드립니다.

먼저 기존 MFARunner로 사전 파일을 생성하면 자모가 일반 자모 코드로 분리됩니다.

```
'{ㅇ ㅣ ㅂ ㅓ ㄴ ㅈ ㅜ ㅇ ㅣ ㄹ ㅛ ㅇ ㅣ ㄹ ㅔ ㅎ ㅏ ㄹ ㅁ ㅓ ㄴ ㅣ ㅊ ㅣ ㄹ ㅅ ㅜ ㄴ ㅈ ㅏ ㄴ ㅊ ㅣ ㄹ ㅡ ㄹ ㅎ ㅏ ㅁ ㄴ ㅣ ㄷ ㅏ}'
```

수정된 코드로 사전 파일을 생성하면 자모가 초성, 중성, 종성 자모 코드로 분리됩니다.

```
'{ᄋ ᅵ ᄇ ᅥ ᆫ ᄌ ᅮ ᄋ ᅵ ᄅ ᅭ ᄋ ᅵ ᄅ ᅦ ᄒ ᅡ ᆯ ᄆ ᅥ ᄂ ᅵ ᄎ ᅵ ᆯ ᄉ ᅮ ᆫ ᄌ ᅡ ᆫ ᄎ ᅵ ᄅ ᅳ ᆯ ᄒ ᅡ ᆷ ᄂ ᅵ ᄃ ᅡ}'
```

https://github.com/HGU-DLLAB/Korean-FastSpeech2-Pytorch 저장소에서는 초성, 중성, 종성 자모 코드만 받고 있기 때문에 이 저장소와 호환되도록 수정하였습니다.